### PR TITLE
fix: Added to asyncronous call avoiding stalled request

### DIFF
--- a/pages/api/user/check-credentials.ts
+++ b/pages/api/user/check-credentials.ts
@@ -9,7 +9,7 @@ export default async function handle(
   res: NextApiResponse,
 ) {
   if (req.method === "POST") {
-    handlePOST(res, req);
+    await handlePOST(res, req);
   } else {
     throw new Error(
       `The HTTP ${req.method} method is not supported at this route.`,


### PR DESCRIPTION
- Stalled requests are avoided by treating the asynchronous call when handling the POST method

`/pages/api/user/check-credentials`
```diff
export default async function handle(
  req: NextApiRequest,
  res: NextApiResponse,
) {
  if (req.method === "POST") {
-    handlePOST(res, req);
+    await handlePOST(res, req);
  } else {
    throw new Error(
      `The HTTP ${req.method} method is not supported at this route.`,
    );
  }
}
```
- With this we avoid the following message when performing the signin process `API resolved without sending a response for /api/user/check-credentials, this may result in stalled requests.`